### PR TITLE
IdleTiming now returns EOF on the first read/write after closing

### DIFF
--- a/idletiming_conn.go
+++ b/idletiming_conn.go
@@ -3,7 +3,10 @@
 package idletiming
 
 import (
+	"errors"
+	"io"
 	"net"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -13,23 +16,22 @@ import (
 var (
 	epoch = time.Unix(0, 0)
 	log   = golog.LoggerFor("idletiming")
+
+	// ErrIdled is return when attempting to use a network connection that was
+	// closed because of idling.
+	ErrIdled = errors.New("Use of idled network connection")
 )
 
 // Conn creates a new net.Conn wrapping the given net.Conn that times out after
-// the specified period. Read and Write calls will timeout if they take longer
-// than the indicated idleTimeout.
+// the specified period. Once a connection has timed out, any pending reads or
+// writes will return io.EOF and the underlying connection will be closed.
 //
 // idleTimeout specifies how long to wait for inactivity before considering
 // connection idle.
 //
-// onIdle is a required function that's called if a connection idles.
-// idletiming.Conn does not close the underlying connection on idle, you have to
-// do that in your onIdle callback.
+// If onIdle is specified, it will be called to indicate when the connection has
+// idled and been closed.
 func Conn(conn net.Conn, idleTimeout time.Duration, onIdle func()) *IdleTimingConn {
-	if onIdle == nil {
-		panic("onIdle is required")
-	}
-
 	c := &IdleTimingConn{
 		conn:             conn,
 		idleTimeout:      idleTimeout,
@@ -50,7 +52,10 @@ func Conn(conn net.Conn, idleTimeout time.Duration, onIdle func()) *IdleTimingCo
 				atomic.StoreInt64(&c.lastActivityTime, time.Now().UnixNano())
 				continue
 			case <-timer.C:
-				onIdle()
+				c.Close()
+				if onIdle != nil {
+					onIdle()
+				}
 				return
 			case <-c.closedCh:
 				return
@@ -70,11 +75,15 @@ type IdleTimingConn struct {
 	writeDeadline    int64
 	lastActivityTime int64
 
-	conn            net.Conn
-	idleTimeout     time.Duration
-	halfIdleTimeout time.Duration
-	activeCh        chan bool
-	closedCh        chan bool
+	conn                net.Conn
+	idleTimeout         time.Duration
+	halfIdleTimeout     time.Duration
+	activeCh            chan bool
+	closedCh            chan bool
+	closeMutex          sync.RWMutex
+	closed              bool
+	hasReadAfterIdle    int32
+	hasWrittenAfterIdle int32
 }
 
 // TimesOutIn returns how much time is left before this connection will time
@@ -91,6 +100,13 @@ func (c *IdleTimingConn) TimesOutAt() time.Time {
 
 // Read implements the method from io.Reader
 func (c *IdleTimingConn) Read(b []byte) (int, error) {
+	c.closeMutex.RLock()
+	defer c.closeMutex.RUnlock()
+
+	if err := c.checkClosed(&c.hasReadAfterIdle); err != nil {
+		return 0, err
+	}
+
 	totalN := 0
 	readDeadline := time.Unix(0, atomic.LoadInt64(&c.readDeadline))
 
@@ -132,6 +148,13 @@ func (c *IdleTimingConn) Read(b []byte) (int, error) {
 
 // Write implements the method from io.Reader
 func (c *IdleTimingConn) Write(b []byte) (int, error) {
+	c.closeMutex.RLock()
+	defer c.closeMutex.RUnlock()
+
+	if err := c.checkClosed(&c.hasWrittenAfterIdle); err != nil {
+		return 0, err
+	}
+
 	totalN := 0
 	writeDeadline := time.Unix(0, atomic.LoadInt64(&c.writeDeadline))
 
@@ -174,6 +197,15 @@ func (c *IdleTimingConn) Write(b []byte) (int, error) {
 // Close this IdleTimingConn. This will close the underlying net.Conn as well,
 // returning the error from calling its Close method.
 func (c *IdleTimingConn) Close() error {
+	c.closeMutex.Lock()
+	defer c.closeMutex.Unlock()
+
+	if err := c.checkClosed(nil); err != nil {
+		return err
+	}
+
+	c.closed = true
+
 	select {
 	case c.closedCh <- true:
 		// close accepted
@@ -184,14 +216,27 @@ func (c *IdleTimingConn) Close() error {
 }
 
 func (c *IdleTimingConn) LocalAddr() net.Addr {
+	c.closeMutex.RLock()
+	defer c.closeMutex.RUnlock()
+
 	return c.conn.LocalAddr()
 }
 
 func (c *IdleTimingConn) RemoteAddr() net.Addr {
+	c.closeMutex.RLock()
+	defer c.closeMutex.RUnlock()
+
 	return c.conn.RemoteAddr()
 }
 
 func (c *IdleTimingConn) SetDeadline(t time.Time) error {
+	c.closeMutex.RLock()
+	defer c.closeMutex.RUnlock()
+
+	if err := c.checkClosed(nil); err != nil {
+		return err
+	}
+
 	if err := c.SetReadDeadline(t); err != nil {
 		log.Tracef("Unable to set read deadline: %v", err)
 	}
@@ -202,11 +247,25 @@ func (c *IdleTimingConn) SetDeadline(t time.Time) error {
 }
 
 func (c *IdleTimingConn) SetReadDeadline(t time.Time) error {
+	c.closeMutex.RLock()
+	defer c.closeMutex.RUnlock()
+
+	if err := c.checkClosed(nil); err != nil {
+		return err
+	}
+
 	atomic.StoreInt64(&c.readDeadline, t.UnixNano())
 	return nil
 }
 
 func (c *IdleTimingConn) SetWriteDeadline(t time.Time) error {
+	c.closeMutex.RLock()
+	defer c.closeMutex.RUnlock()
+
+	if err := c.checkClosed(nil); err != nil {
+		return err
+	}
+
 	atomic.StoreInt64(&c.writeDeadline, t.UnixNano())
 	return nil
 }
@@ -215,9 +274,18 @@ func (c *IdleTimingConn) markActive(n int) bool {
 	if n > 0 {
 		c.activeCh <- true
 		return true
-	} else {
-		return false
 	}
+	return false
+}
+
+func (c *IdleTimingConn) checkClosed(hasDone *int32) error {
+	if c.closed {
+		if hasDone != nil && atomic.CompareAndSwapInt32(hasDone, 0, 1) {
+			return io.EOF
+		}
+		return ErrIdled
+	}
+	return nil
 }
 
 func isTimeout(err error) bool {

--- a/idletiming_test.go
+++ b/idletiming_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/getlantern/fdcount"
+	"github.com/stretchr/testify/assert"
 )
 
 var (
@@ -39,9 +40,6 @@ func TestWrite(t *testing.T) {
 	addr := l.Addr().String()
 	il := Listener(l, serverTimeout, func(conn net.Conn) {
 		atomic.StoreInt32(&listenerIdled, 1)
-		if err := conn.Close(); err != nil {
-			t.Errorf("Unable to close connection: %v", err)
-		}
 	})
 	defer func() {
 		if err := il.Close(); err != nil {
@@ -76,9 +74,6 @@ func TestWrite(t *testing.T) {
 
 	c := Conn(conn, clientTimeout, func() {
 		atomic.StoreInt32(&connIdled, 1)
-		if err := conn.Close(); err != nil {
-			t.Fatalf("Unable to close connection: %v", err)
-		}
 	})
 
 	// Write messages
@@ -103,9 +98,15 @@ func TestWrite(t *testing.T) {
 	}
 
 	time.Sleep(slightlyMoreThanClientTimeout)
-	if connIdled == 0 {
+	if atomic.LoadInt32(&connIdled) == 0 {
 		t.Errorf("Conn failed to idle!")
 	}
+
+	time.Sleep(slightlyMoreThanClientTimeout)
+	_, err = c.Write(make([]byte, 10))
+	assert.Equal(t, io.EOF, err, "1st write after idle should return io.EOF")
+	_, err = c.Write(make([]byte, 10))
+	assert.Equal(t, ErrIdled, err, "2nd write after idle should return ErrIdled")
 
 	connTimesOutIn := c.TimesOutIn()
 	if connTimesOutIn > 0 {
@@ -113,7 +114,7 @@ func TestWrite(t *testing.T) {
 	}
 
 	time.Sleep(9 * slightlyMoreThanClientTimeout)
-	if listenerIdled == 0 {
+	if atomic.LoadInt32(&listenerIdled) == 0 {
 		t.Errorf("Listener failed to idle!")
 	}
 }
@@ -124,8 +125,8 @@ func TestRead(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	listenerIdled := int32(0)
 	connIdled := int32(0)
+	listenerIdled := int32(0)
 
 	l, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
@@ -134,9 +135,6 @@ func TestRead(t *testing.T) {
 
 	il := Listener(l, serverTimeout, func(conn net.Conn) {
 		atomic.StoreInt32(&listenerIdled, 1)
-		if err := conn.Close(); err != nil {
-			t.Fatalf("Unable to close connection: %v", err)
-		}
 	})
 	defer func() {
 		if err := il.Close(); err != nil {
@@ -176,9 +174,6 @@ func TestRead(t *testing.T) {
 
 	c := Conn(conn, clientTimeout, func() {
 		atomic.StoreInt32(&connIdled, 1)
-		if err := conn.Close(); err != nil {
-			t.Fatalf("Unable to close connection: %v", err)
-		}
 	})
 
 	// Read messages (we use a buffer matching the message size to make sure
@@ -211,12 +206,16 @@ func TestRead(t *testing.T) {
 	}
 
 	time.Sleep(slightlyMoreThanClientTimeout)
-	if connIdled == 0 {
+	if atomic.LoadInt32(&connIdled) == 0 {
 		t.Errorf("Conn failed to idle!")
 	}
+	_, err = c.Read(make([]byte, 10))
+	assert.Equal(t, io.EOF, err, "1st read after idle should return io.EOF")
+	_, err = c.Read(make([]byte, 10))
+	assert.Equal(t, ErrIdled, err, "2nd read after idle should return ErrIdled")
 
 	time.Sleep(9 * slightlyMoreThanClientTimeout)
-	if listenerIdled == 0 {
+	if atomic.LoadInt32(&listenerIdled) == 0 {
 		t.Errorf("Listener failed to idle!")
 	}
 }


### PR DESCRIPTION
I noticed that our idletiming is poorly behaved.  Specifically, it closes the underlying connection, so any pending reads or writes return "Use of closed network connection" errors.  This PR make idletiming look as if the remote end closed the connection, by returning io.EOF for pending reads and writes.